### PR TITLE
Changed requested permissions due to LinkedIN API policy changes 

### DIFF
--- a/LinkedIn/Pages/Account.php
+++ b/LinkedIn/Pages/Account.php
@@ -22,7 +22,7 @@
                             $login_url = $linkedinAPI->getAuthenticationUrl(
                                 \IdnoPlugins\LinkedIn\Main::$AUTHORIZATION_ENDPOINT,
                                 \IdnoPlugins\LinkedIn\Main::getRedirectUrl(),
-                                ['scope' => 'rw_nus,rw_company_admin,r_fullprofile,r_basicprofile', 'response_type' => 'code', 'state' => \IdnoPlugins\LinkedIn\Main::getState()]
+                                ['scope' => 'w_share,rw_company_admin,r_emailaddress,r_basicprofile', 'response_type' => 'code', 'state' => \IdnoPlugins\LinkedIn\Main::getState()]
                             );
 
                         }


### PR DESCRIPTION
Starting May 12th 2015 new applications for API access require different permissions. The old r_fullprofile is not available anymore by default. This resulted in an error while connecting LinkedIn accounts.

See link for more details:
https://developer.linkedin.com/support/developer-program-transition
